### PR TITLE
Add click debounce time changing

### DIFF
--- a/gloriousctl.c
+++ b/gloriousctl.c
@@ -119,6 +119,7 @@ RBG8 int_to_rbg(unsigned int value)
 
 #define CMD_CONFIG 0x11
 #define CONFIG_SIZE 520
+#define CONFIG_SIZE_USED 131
 #define REPORT_ID_CMD 0x5
 #define REPORT_ID_CONFIG 0x4
 #define XY_INDEPENDENT 0x80
@@ -128,8 +129,8 @@ struct config {
     uint8_t command_id;
     uint8_t unk1;
     uint8_t config_write;
-    /* always 0 when config is read from device,
-     * has to be 0x7b when writing config to device
+    /* 0x0 - read.
+     * CONFIG_SIZE_USED-8 - write.
      */
     uint8_t unk2[6];
     uint8_t config1;
@@ -582,7 +583,7 @@ int main(int argc, char* argv[])
 
             dump_config(cfg);
 
-            cfg->config_write = 0x7b;
+            cfg->config_write = CONFIG_SIZE_USED - 8;
 
             res = hid_send_feature_report(dev, (uint8_t*)cfg, CONFIG_SIZE);
             if(res == -1) {

--- a/gloriousctl.c
+++ b/gloriousctl.c
@@ -126,6 +126,7 @@ RBG8 int_to_rbg(unsigned int value)
 #define CMD_CONFIG 0x11
 #define CONFIG_SIZE 520
 #define CONFIG_SIZE_USED 131
+#define NUM_DPIS 6
 #define REPORT_ID_CMD 0x5
 #define REPORT_ID_CONFIG 0x4
 #define XY_INDEPENDENT 0x80
@@ -262,7 +263,7 @@ void dump_config(const struct config *cfg)
 {
     int xy_independent = (cfg->config1 & XY_INDEPENDENT) == XY_INDEPENDENT;
     printf("XY DPI independent: %s\n", xy_independent ? "yes" : "no");
-    for(unsigned int i = 0; i < 6; i++) {
+    for(unsigned int i = 0; i < NUM_DPIS; i++) {
         if(cfg->dpi_enabled & (1U<<i)) {
             printf("[ ] ");
         } else {
@@ -527,7 +528,7 @@ int main(int argc, char* argv[])
             }
         } else if(do_set) {
             if(set_dpi) {
-                int dpi[6] = {0};
+                int dpi[NUM_DPIS] = {0};
                 unsigned int num_dpis = sscanf(set_dpi, "%d,%d,%d,%d,%d,%d", &dpi[0], &dpi[1], &dpi[2],
                                       &dpi[3], &dpi[4], &dpi[5]);
                 cfg->dpi_enabled = 0xff;
@@ -540,7 +541,7 @@ int main(int argc, char* argv[])
                 printf("%s %d\n", set_dpi, num_dpis);
             }
             if(set_dpi_color) {
-                unsigned int dpi_color[6] = {0};
+                unsigned int dpi_color[NUM_DPIS] = {0};
                 unsigned int num_colors = sscanf(set_dpi_color, "%x,%x,%x,%x,%x,%x", &dpi_color[0], &dpi_color[1],
                                         &dpi_color[2], &dpi_color[3], &dpi_color[4], &dpi_color[5]);
                 for(unsigned int i = 0; i < num_colors; i++) {

--- a/gloriousctl.c
+++ b/gloriousctl.c
@@ -333,6 +333,26 @@ void print_hid_error(hid_device *handle, const char *operation)
 }
 
 static
+int print_firmware_version(hid_device *dev)
+{
+    int res = 0;
+    uint8_t version[6] = {0x5, 0x1};
+    res = hid_send_feature_report(dev, version, sizeof(version));
+    if(res != sizeof(version)) {
+        print_hid_error(dev, "get firmware version command");
+        return 1;
+    }
+    res = hid_get_feature_report(dev, version, sizeof(version));
+    if(res != sizeof(version)) {
+        print_hid_error(dev, "read firmware version");
+        return 1;
+    }
+    printf("Firmware version: %.4s\n", version + 2);
+
+    return 0;
+}
+
+static
 int print_help()
 {
     fprintf(stderr,
@@ -461,18 +481,10 @@ int main(int argc, char* argv[])
 
         printf("%lu\n", sizeof(struct config));
 
-        uint8_t version[6] = {0x5, 0x1};
-        res = hid_send_feature_report(dev, version, sizeof(version));
-        if(res != sizeof(version)) {
-            print_hid_error(dev, "get firmware version command");
-            return 1;
+        res = print_firmware_version(dev);
+        if (res) {
+            return res;
         }
-        res = hid_get_feature_report(dev, version, sizeof(version));
-        if(res != sizeof(version)) {
-            print_hid_error(dev, "read firmware version");
-            return 1;
-        }
-        printf("Firmware version: %.4s\n", version + 2);
 
         uint8_t cmd[6] = {REPORT_ID_CMD, CMD_CONFIG};
         res = hid_send_feature_report(dev, cmd, sizeof(cmd));

--- a/gloriousctl.c
+++ b/gloriousctl.c
@@ -117,6 +117,10 @@ RBG8 int_to_rbg(unsigned int value)
     return rgb;
 }
 
+#define CMD_CONFIG 0x11
+#define CONFIG_SIZE 520
+#define REPORT_ID_CMD 0x5
+#define REPORT_ID_CONFIG 0x4
 #define XY_INDEPENDENT 0x80
 
 struct config {
@@ -461,17 +465,17 @@ int main(int argc, char* argv[])
         }
         printf("Firmware version: %.4s\n", version + 2);
 
-        uint8_t cmd[6] = {0x5, 0x11};
+        uint8_t cmd[6] = {REPORT_ID_CMD, CMD_CONFIG};
         res = hid_send_feature_report(dev, cmd, sizeof(cmd));
         if(res != sizeof(cmd)) {
             print_hid_error(dev, "get config command");
             return 1;
         }
 
-        struct config *cfg = calloc(1, 520);
-        cfg->report_id = 0x4;
+        struct config *cfg = calloc(1, CONFIG_SIZE);
+        cfg->report_id = REPORT_ID_CONFIG;
         /* this isn't portable code anyway due to packed structs */
-        res = hid_get_feature_report(dev, (uint8_t*)cfg, 520);
+        res = hid_get_feature_report(dev, (uint8_t*)cfg, CONFIG_SIZE);
         if(res == -1) {
             print_hid_error(dev, "read config");
             return 1;
@@ -580,7 +584,7 @@ int main(int argc, char* argv[])
 
             cfg->config_write = 0x7b;
 
-            res = hid_send_feature_report(dev, (uint8_t*)cfg, 520);
+            res = hid_send_feature_report(dev, (uint8_t*)cfg, CONFIG_SIZE);
             if(res == -1) {
                 print_hid_error(dev, "write config");
                 return 1;

--- a/gloriousctl.c
+++ b/gloriousctl.c
@@ -1,12 +1,13 @@
+#include <fcntl.h>
 #include <getopt.h>
+#include <stddef.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <stdint.h>
 #include <string.h>
-#include <hidapi/hidapi.h>
-
 #include <sys/types.h>
-#include <fcntl.h>
+
+#include <hidapi/hidapi.h>
 
 #define MAX_STR 255
 
@@ -255,8 +256,6 @@ unsigned int clamp(unsigned int value, unsigned int lower, unsigned int upper)
 
     return value;
 }
-
-#include <stddef.h>
 
 static
 void dump_config(const struct config *cfg)

--- a/gloriousctl.c
+++ b/gloriousctl.c
@@ -443,9 +443,9 @@ int main(int argc, char* argv[])
         return print_help();
     }
     if(do_info || do_set || do_listen) {
-        int res;
+        int res = 0;
         char *dev_path = detect_device();
-        hid_device *dev;
+        hid_device *dev = NULL;
 
         if(!dev_path) {
             fprintf(stderr, "No supported device found.\n");
@@ -610,7 +610,7 @@ int main(int argc, char* argv[])
 
 /* from https://stackoverflow.com/a/7776146/675646 */
 void hexDump (const char * desc, const void * addr, const int len) {
-    int i;
+    int i = 0;
     unsigned char buff[17];
     const unsigned char * pc = (const unsigned char *)addr;
 

--- a/gloriousctl.c
+++ b/gloriousctl.c
@@ -106,8 +106,8 @@ static
 RGB8 int_to_rgb(unsigned int value)
 {
     RGB8 rgb;
-    rgb.r = value >> 16;
-    rgb.g = value >> 8;
+    rgb.r = value >> 16U;
+    rgb.g = value >> 8U;
     rgb.b = value;
     return rgb;
 }
@@ -116,8 +116,8 @@ static
 RBG8 int_to_rbg(unsigned int value)
 {
     RBG8 rgb;
-    rgb.r = value >> 16;
-    rgb.g = value >> 8;
+    rgb.r = value >> 16U;
+    rgb.g = value >> 8U;
     rgb.b = value;
     return rgb;
 }
@@ -155,40 +155,40 @@ struct config {
      */
     RGB8 dpi_color[8];
 
-    char rgb_effect;
+    uint8_t rgb_effect;
     /* see enum rgb_effect */
 
-    char glorious_mode;
+    uint8_t glorious_mode;
     /* 0x40 - brightness (constant)
      * 0x1/2/3 - speed
      */
-    char glorious_direction;
+    uint8_t glorious_direction;
 
     uint8_t single_mode;
     RBG8 single_color;
 
-    char breathing7_mode;
+    uint8_t breathing7_mode;
     /* 0x40 - brightness (constant)
      * 0x1/2/3 - speed
      */
-    char breathing7_colorcount;
+    uint8_t breathing7_colorcount;
     /* 7, constant */
     RBG8 breathing7_colors[7];
 
-    char tail_mode;
+    uint8_t tail_mode;
     /* 0x10/20/30/40 - brightness
      * 0x1/2/3 - speed
      */
 
     uint8_t unk4[33];
 
-    char rave_mode;
+    uint8_t rave_mode;
     /* 0x10/20/30/40 - brightness
      * 0x1/2/3 - speed
      */
     RBG8 rave_colors[2];
 
-    char wave_mode;
+    uint8_t wave_mode;
     /* 0x10/20/30/40 - brightness
      * 0x1/2/3 - speed
      */
@@ -197,11 +197,11 @@ struct config {
     /* 0x1/2/3 - speed */
     RBG8 breathing1_color;
 
-    char unk5;
-    char lift_off_distance;
+    uint8_t unk5;
     /* 0x1 - 2 mm
      * 0x2 - 3 mm
      */
+    uint8_t lift_off_distance;
 };
 
 struct change_report {
@@ -244,7 +244,7 @@ void print_color_rbg(RBG8 color)
 }
 
 static
-int clamp(int value, int lower, int upper)
+unsigned int clamp(unsigned int value, unsigned int lower, unsigned int upper)
 {
     if(value < lower) {
         return lower;
@@ -263,8 +263,8 @@ void dump_config(const struct config *cfg)
 {
     int xy_independent = (cfg->config1 & XY_INDEPENDENT) == XY_INDEPENDENT;
     printf("XY DPI independent: %s\n", xy_independent ? "yes" : "no");
-    for(int i = 0; i < 6; i++) {
-        if(cfg->dpi_enabled & (1<<i)) {
+    for(unsigned int i = 0; i < 6; i++) {
+        if(cfg->dpi_enabled & (1U<<i)) {
             printf("[ ] ");
         } else {
             if(cfg->active_dpi == i) {
@@ -310,7 +310,7 @@ char *detect_device()
     hid_init();
 
     char *path = NULL;
-    for(unsigned i = 0; i < sizeof(supported_devices)/sizeof(supported_devices[0]); i++) {
+    for(unsigned int i = 0; i < sizeof(supported_devices)/sizeof(supported_devices[0]); i++) {
         path = find_device(&supported_devices[i]);
         if(path) {
             fprintf(stderr, "Detected %s\n", supported_devices[i].name);
@@ -370,7 +370,7 @@ int print_help()
         );
 
     fprintf(stderr, "Supported mice:\n");
-    for(unsigned i = 0; i < sizeof(supported_devices)/sizeof(supported_devices[0]); i++) {
+    for(unsigned int i = 0; i < sizeof(supported_devices)/sizeof(supported_devices[0]); i++) {
         struct supported_device dev = supported_devices[i];
         fprintf(stderr, " - %s (VID %04x PID %04x)\n", dev.name, dev.vid, dev.pid);
     }
@@ -512,32 +512,31 @@ int main(int argc, char* argv[])
                 hexDump("inpr", &report, sizeof(report));
             }
         } else if(do_set) {
-
             if(set_dpi) {
                 int dpi[6] = {0};
-                int num_dpis = sscanf(set_dpi, "%d,%d,%d,%d,%d,%d", &dpi[0], &dpi[1], &dpi[2],
+                unsigned int num_dpis = sscanf(set_dpi, "%d,%d,%d,%d,%d,%d", &dpi[0], &dpi[1], &dpi[2],
                                       &dpi[3], &dpi[4], &dpi[5]);
                 cfg->dpi_enabled = 0xff;
                 cfg->dpi_count = 0;
-                for(int i = 0; i < num_dpis; i++) {
+                for(unsigned int i = 0; i < num_dpis; i++) {
                     cfg->dpi[i] = dpi_to_config(dpi[i]);
-                    cfg->dpi_enabled &= ~(1<<i);
+                    cfg->dpi_enabled &= ~(1U<<i);
                     cfg->dpi_count++;
                 }
                 printf("%s %d\n", set_dpi, num_dpis);
             }
             if(set_dpi_color) {
                 unsigned int dpi_color[6] = {0};
-                int num_colors = sscanf(set_dpi_color, "%x,%x,%x,%x,%x,%x", &dpi_color[0], &dpi_color[1],
+                unsigned int num_colors = sscanf(set_dpi_color, "%x,%x,%x,%x,%x,%x", &dpi_color[0], &dpi_color[1],
                                         &dpi_color[2], &dpi_color[3], &dpi_color[4], &dpi_color[5]);
-                for(int i = 0; i < num_colors; i++) {
+                for(unsigned int i = 0; i < num_colors; i++) {
                     cfg->dpi_color[i] = int_to_rgb(dpi_color[i]);
                 }
             }
             if(set_effect) {
                 cfg->rgb_effect = name_to_rgb_effect(set_effect);
                 unsigned int rgb_colors[7] = {0};
-                int num_colors = sscanf(set_effect_colors,  "%x,%x,%x,%x,%x,%x,%x", &rgb_colors[0],
+                unsigned int num_colors = sscanf(set_effect_colors,  "%x,%x,%x,%x,%x,%x,%x", &rgb_colors[0],
                                         &rgb_colors[1], &rgb_colors[2], &rgb_colors[3], &rgb_colors[4],
                                         &rgb_colors[5], &rgb_colors[6]);
                 switch(cfg->rgb_effect) {
@@ -545,7 +544,7 @@ int main(int argc, char* argv[])
                     cfg->single_color = int_to_rbg(rgb_colors[0]);
                     break;
                 case RGB_BREATHING7:
-                    for(int i = 0; i < num_colors; i++) {
+                    for(unsigned int i = 0; i < num_colors; i++) {
                         cfg->breathing7_colors[i] = int_to_rbg(rgb_colors[i]);
                     }
                     break;
@@ -557,12 +556,13 @@ int main(int argc, char* argv[])
                     cfg->rave_colors[0] = int_to_rbg(rgb_colors[1]);
                 }
 
-                int brightness = 4, speed = 3;
+                unsigned int brightness = 4;
+                unsigned int speed = 3;
                 sscanf(set_effect_brightness, "%d", &brightness);
                 sscanf(set_effect_speed, "%d", &speed);
                 brightness = clamp(brightness, 0, 4);
                 speed = clamp(speed, 0, 3);
-                uint8_t mode = speed | (brightness << 4);
+                uint8_t mode = speed | (brightness << 4U);
 
                 switch(cfg->rgb_effect) {
                 case RGB_GLORIOUS:

--- a/gloriousctl.c
+++ b/gloriousctl.c
@@ -486,11 +486,13 @@ int main(int argc, char* argv[])
             return res;
         }
 
-        uint8_t cmd[6] = {REPORT_ID_CMD, CMD_CONFIG};
-        res = hid_send_feature_report(dev, cmd, sizeof(cmd));
-        if(res != sizeof(cmd)) {
-            print_hid_error(dev, "get config command");
-            return 1;
+        {
+            uint8_t cmd[6] = {REPORT_ID_CMD, CMD_CONFIG};
+            res = hid_send_feature_report(dev, cmd, sizeof(cmd));
+            if(res != sizeof(cmd)) {
+                print_hid_error(dev, "get config command");
+                return 1;
+            }
         }
 
         struct config *cfg = calloc(1, CONFIG_SIZE);

--- a/gloriousctl.c
+++ b/gloriousctl.c
@@ -74,27 +74,32 @@ const char *rgb_effect_to_name(enum rgb_effect rgb_effect)
 static
 enum rgb_effect name_to_rgb_effect(const char *name)
 {
-    if(!strcmp(name, "off")) {
-        return RGB_OFF;
-    } else if(!strcmp(name, "glorious")) {
+    if(!strcmp(name, "glorious")) {
         return RGB_GLORIOUS;
-    } else if(!strcmp(name, "single")) {
-        return RGB_SINGLE;
-    } else if(!strcmp(name, "breathing")) {
-        return RGB_BREATHING;
-    } else if(!strcmp(name, "breathing7")) {
-        return RGB_BREATHING7;
-    } else if(!strcmp(name, "breathing1")) {
-        return RGB_BREATHING1;
-    } else if(!strcmp(name, "tail")) {
-        return RGB_TAIL;
-    } else if(!strcmp(name, "rave")) {
-        return RGB_RAVE;
-    } else if(!strcmp(name, "wave")) {
-        return RGB_WAVE;
-    } else {
-        return RGB_OFF;
     }
+    if(!strcmp(name, "single")) {
+        return RGB_SINGLE;
+    }
+    if(!strcmp(name, "breathing")) {
+        return RGB_BREATHING;
+    }
+    if(!strcmp(name, "breathing7")) {
+        return RGB_BREATHING7;
+    }
+    if(!strcmp(name, "breathing1")) {
+        return RGB_BREATHING1;
+    }
+    if(!strcmp(name, "tail")) {
+        return RGB_TAIL;
+    }
+    if(!strcmp(name, "rave")) {
+        return RGB_RAVE;
+    }
+    if(!strcmp(name, "wave")) {
+        return RGB_WAVE;
+    }
+
+    return RGB_OFF;
 }
 
 static
@@ -243,9 +248,11 @@ int clamp(int value, int lower, int upper)
 {
     if(value < lower) {
         return lower;
-    } else if(value > upper) {
+    }
+    if(value > upper) {
         return upper;
     }
+
     return value;
 }
 
@@ -434,7 +441,8 @@ int main(int argc, char* argv[])
 
     if(do_help) {
         return print_help();
-    } else if(do_info || do_set || do_listen) {
+    }
+    if(do_info || do_set || do_listen) {
         int res;
         char *dev_path = detect_device();
         hid_device *dev;
@@ -617,7 +625,7 @@ void hexDump (const char * desc, const void * addr, const int len) {
         printf("  ZERO LENGTH\n");
         return;
     }
-    else if (len < 0) {
+    if (len < 0) {
         printf("  NEGATIVE LENGTH: %d\n", len);
         return;
     }

--- a/gloriousctl.c
+++ b/gloriousctl.c
@@ -30,6 +30,8 @@ struct supported_device {
  * is the same as the glorious software.
  */
 static struct supported_device supported_devices[] = {
+    // G-Wolves Hati has the same PID, but uses a different report ID for changing configuration (0x6).
+    { .vid = 0x258a, .pid = 0x27, .name =  "Dream Machines DM5" },
     { .vid = 0x258a, .pid = 0x33, .name =  "Glorious Model D" },
     { .vid = 0x258a, .pid = 0x36, .name =  "Glorious Model O/O-" }, // probably works
 };

--- a/gloriousctl.c
+++ b/gloriousctl.c
@@ -67,8 +67,8 @@ const char *rgb_effect_to_name(enum rgb_effect rgb_effect)
     case RGB_TAIL: return "Tail effect";
     case RGB_RAVE: return "Two-color rave!11";
     case RGB_WAVE: return "Wave effect";
+    default: return "control reaches end of non-void function";
     }
-    return "control reaches end of non-void function";
 }
 
 static
@@ -436,6 +436,7 @@ int main(int argc, char* argv[])
         case 'f':
             set_effect_speed = optarg;
             break;
+        default:;
         }
     }
 

--- a/gloriousctl.c
+++ b/gloriousctl.c
@@ -134,68 +134,68 @@ struct config {
     uint8_t report_id;
     uint8_t command_id;
     uint8_t unk1;
-    uint8_t config_write;
     /* 0x0 - read.
      * CONFIG_SIZE_USED-8 - write.
      */
+    uint8_t config_write;
     uint8_t unk2[6];
-    uint8_t config1;
     /* 0x80 - XY DPI independent */
+    uint8_t config1;
     uint8_t dpi_count:4;
     uint8_t active_dpi:4;
-    uint8_t dpi_enabled;
     /* bit set: disabled, unset: enabled
      * this structure has support for eight DPI slots,
      * but the glorious software only exposes six
      */
-    uint8_t dpi[16];
+    uint8_t dpi_enabled;
     /* DPI/CPI is encoded in the way the PMW3360 sensor accepts it
      * value = (DPI - 100) / 100
      * If XY are identical, dpi[0-6] contain the sensitivities,
      * while in XY independent mode each entry takes two chars for X and Y.
      */
+    uint8_t dpi[16];
     RGB8 dpi_color[8];
 
-    uint8_t rgb_effect;
     /* see enum rgb_effect */
+    uint8_t rgb_effect;
 
-    uint8_t glorious_mode;
     /* 0x40 - brightness (constant)
      * 0x1/2/3 - speed
      */
+    uint8_t glorious_mode;
     uint8_t glorious_direction;
 
     uint8_t single_mode;
     RBG8 single_color;
 
-    uint8_t breathing7_mode;
     /* 0x40 - brightness (constant)
      * 0x1/2/3 - speed
      */
-    uint8_t breathing7_colorcount;
+    uint8_t breathing7_mode;
     /* 7, constant */
+    uint8_t breathing7_colorcount;
     RBG8 breathing7_colors[7];
 
-    uint8_t tail_mode;
     /* 0x10/20/30/40 - brightness
      * 0x1/2/3 - speed
      */
+    uint8_t tail_mode;
 
     uint8_t unk4[33];
 
-    uint8_t rave_mode;
     /* 0x10/20/30/40 - brightness
      * 0x1/2/3 - speed
      */
+    uint8_t rave_mode;
     RBG8 rave_colors[2];
 
-    uint8_t wave_mode;
     /* 0x10/20/30/40 - brightness
      * 0x1/2/3 - speed
      */
+    uint8_t wave_mode;
 
-    uint8_t breathing1_mode;
     /* 0x1/2/3 - speed */
+    uint8_t breathing1_mode;
     RBG8 breathing1_color;
 
     uint8_t unk5;

--- a/gloriousctl.c
+++ b/gloriousctl.c
@@ -238,14 +238,6 @@ void print_color(RGB8 color)
 }
 
 static
-void print_color_rbg(RBG8 color)
-{
-    printf("\e[38;2;%d;%d;%dm", color.r, color.g, color.b);
-    printf("#%02X%02X%02X", color.r, color.g, color.b);
-    printf("\e[39m");
-}
-
-static
 unsigned int clamp(unsigned int value, unsigned int lower, unsigned int upper)
 {
     if(value < lower) {


### PR DESCRIPTION
Closes #2. De-bounce time can be set to 2 ms, but I limited it at 4 as that's the lowest value official software allows. Also, as click de-bounce time is changed not in the configuration data but by a separate command, so it doesn't get printed by `dump_config`.

I also did some other changes, hope you don't mind.