### PR TITLE
build: do not hardcode gcc

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 all: gloriousctl
 
 gloriousctl: gloriousctl.c
-	gcc -Wall -Wextra gloriousctl.c -lhidapi-hidraw -o gloriousctl -g
+	$(CC) -Wall -Wextra gloriousctl.c -lhidapi-hidraw -o gloriousctl -g
 
 .PHONY: clean
 


### PR DESCRIPTION
CC is an implicit variable defaulting to cc.

See: https://www.gnu.org/software/make/manual/html_node/Implicit-Variables.html